### PR TITLE
Add rate limiting middleware with koa2-ratelimit

### DIFF
--- a/config/middlewares.ts
+++ b/config/middlewares.ts
@@ -50,4 +50,5 @@ export default [
     'strapi::session',
     'strapi::favicon',
     'strapi::public',
+    'global::rate-limit',
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@strapi/plugin-users-permissions": "^5.10.2",
                 "@strapi/provider-upload-aws-s3": "^5.10.2",
                 "@strapi/strapi": "^5.10.2",
+                "koa2-ratelimit": "^1.1.3",
                 "music-metadata": "^10.9.0",
                 "pg": "~8.13.1",
                 "prettify-xml": "^1.2.0",
@@ -22,6 +23,7 @@
                 "styled-components": "~6.1.15"
             },
             "devDependencies": {
+                "@types/koa2-ratelimit": "^0.9.6",
                 "@types/node": "^20.17.18",
                 "@types/react": "^18.3.18",
                 "@types/react-dom": "^18.3.5",
@@ -216,6 +218,1071 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.749.0.tgz",
+            "integrity": "sha512-i6rJTXVGD15Ha3Xx+NJAITXQGNo8Gyq2GSumZstuG1qjY4aiZsQgnNjLNal+ayf8iQPdtxKHc+/okUHqACMh0A==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/credential-provider-node": "3.749.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.749.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.3",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.4",
+                "@smithy/middleware-retry": "^4.0.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.5",
+                "@smithy/util-defaults-mode-node": "^4.0.5",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.749.0.tgz",
+            "integrity": "sha512-ecmuDu8EPya1LDpGRtpgN7C9PHayDh8EaW37ZBKhuxA7cg099yvTFqsGngwRXbhNjKJ4oVa9OUe0EDnu60atYA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.749.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.3",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.4",
+                "@smithy/middleware-retry": "^4.0.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.5",
+                "@smithy/util-defaults-mode-node": "^4.0.5",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.749.0.tgz",
+            "integrity": "sha512-w5Jj573+XKwrDNZUjUJDXL5upx+RCw64TLq3Zk8FVg9MsgkzAPorQ9qmzffi6os+PWngd3pFmD8q5y+Y35LpFQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.749.0.tgz",
+            "integrity": "sha512-bhB1ds5QzcSfmCTbjVessXy8xHJROota6wOhFtBsL1aZRQyNN2a9h2QS6xkxjmqVE3yHBsPz+OiSOeLn0kxm7Q==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.749.0.tgz",
+            "integrity": "sha512-enFGT8uvETbE6+4bDA2aTOrA/83GrIVPpg2g2r7MwJb36jreXA3KDXaP/5jQsxyIZW70cnYNl/Cawdd4ZXs7CQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.749.0.tgz",
+            "integrity": "sha512-OB4AGK61lQdoW2mTmaMBw8L+eBo7wF3YJZXwqFI7M2cQe9WtfuKGIxbYWMBMzoLvEtmsbzeppoZZUezooaIclg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/credential-provider-env": "3.749.0",
+                "@aws-sdk/credential-provider-http": "3.749.0",
+                "@aws-sdk/credential-provider-process": "3.749.0",
+                "@aws-sdk/credential-provider-sso": "3.749.0",
+                "@aws-sdk/credential-provider-web-identity": "3.749.0",
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.749.0.tgz",
+            "integrity": "sha512-1QGstZmGmgmY0rLSTAURlBJdR4s2PRYiZh6dS4HkzzQu7xVDWoCMD+2F7dolsNA8ChTNx2OvBW80n3O9QPICCg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.749.0",
+                "@aws-sdk/credential-provider-http": "3.749.0",
+                "@aws-sdk/credential-provider-ini": "3.749.0",
+                "@aws-sdk/credential-provider-process": "3.749.0",
+                "@aws-sdk/credential-provider-sso": "3.749.0",
+                "@aws-sdk/credential-provider-web-identity": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.749.0.tgz",
+            "integrity": "sha512-C/cgg/AhRabybZRY9mJ6KDz8uqfasWKuFIFGzTpeb/MIDIL53ZqP61CspiQJTRvC4zlFGqvm43XefphfrBGGlQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.749.0.tgz",
+            "integrity": "sha512-bQNgWcYk10fYOvFwcLskYYVNLO3KMgmV1ip9ieapJb9JDg6bSBaXNjIDhdpK4biTOfrV+adtDO5EU93ogpmAWA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.749.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/token-providers": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.749.0.tgz",
+            "integrity": "sha512-jzHk6i4G4dnXL+L+qeILguDCiIhA1rNvJzB5lTts4R8OdmNkG12bGbYL8bL4O1b5qCimlo7HS0IZIby0pS7rcg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.749.0.tgz",
+            "integrity": "sha512-dNRkZtiM8OoGb/h2Fgrgvty9ltYEubzsD5FH+VN14RrluertLQMmqHrgvq7JoAXFf7MJy+uwhRu4V6pf1sZR/w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.749.0.tgz",
+            "integrity": "sha512-s3ExVWoNZan6U7ljMqjiHq3bOe4EqL+U+cVPwqNxAsMaJpGyCiA8VQFlXNGg0EPAFbz/0DVBcozYht6/vyH3sg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.749.0.tgz",
+            "integrity": "sha512-uBzolGGrwvZKhpYlGIy9tw6gRdqVs2zyjjXUiifdgbr3WiQXJe8sE1KhLjzyN/VOPcZB0rY34ybqiKEDOymOeQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/core": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.4.tgz",
+            "integrity": "sha512-wFExFGK+7r2wYriOqe7RRIBNpvxwiS95ih09+GSLRBdoyK/O1uZA7K7pKesj5CBvwJuSBeXwLyR88WwIAY+DGA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.5.tgz",
+            "integrity": "sha512-cPzGZV7qStHwboFrm6GfrzQE+YDiCzWcTh4+7wKrP/ZQ4gkw+r7qDjV8GjM4N0UYsuUyLfpzLGg5hxsYTU11WA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.4",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.6.tgz",
+            "integrity": "sha512-s8QzuOQnbdvRymD9Gt9c9zMq10wUQAHQ3z72uirrBHCwZcLTrL5iCOuVTMdka2IXOYhQE890WD5t6G24+F+Qcg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
+            "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/smithy-client": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.5.tgz",
+            "integrity": "sha512-DMXYoYeL4QkElr216n1yodTFeATbfb4jwYM9gKn71Rw/FNA1/Sm36tkTSCsZEs7mgpG3OINmkxL9vgVFzyGPaw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.4",
+                "@smithy/middleware-endpoint": "^4.0.5",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.6.tgz",
+            "integrity": "sha512-N8+VCt+piupH1A7DgSVDNrVHqRLz8r6DvBkpS7EWHiIxsUk4jqGuQLjqC/gnCzmwGkVBdNruHoYAzzaSQ8e80w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.6.tgz",
+            "integrity": "sha512-9zhx1shd1VwSSVvLZB8CM3qQ3RPD3le7A3h/UPuyh/PC7g4OaWDi2xUNzamsVoSmCGtmUBONl56lM2EU6LcH7A==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.1.tgz",
+            "integrity": "sha512-+Xvh8nhy0Wjv1y71rBVyV3eJU3356XsFQNI8dEZVNrQju7Eib8G31GWtO+zMa9kTCGd41Mflu+ZKfmQL/o2XzQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                }
+            ],
+            "optional": true,
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws-sdk/client-s3": {
@@ -499,6 +1566,64 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.749.0.tgz",
+            "integrity": "sha512-Ny2MEuG1YR/PaDo0s0bUf1YSU3+uVrOs4cxL00+pakbGMJtGjMhOB/cUoNCCvOc637WvkUHSkvlrpDmSDo5gYA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.598.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
@@ -709,6 +1834,1049 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.749.0.tgz",
+            "integrity": "sha512-8nkglU8UGRxSSvnqe2Hq76eBjSyK18QbHZVxwNl26K3j085SIqhvnpRSZYt/eBMYMrDyOP3Tlw51Ya8MoQUCmg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.749.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.749.0",
+                "@aws-sdk/credential-provider-env": "3.749.0",
+                "@aws-sdk/credential-provider-http": "3.749.0",
+                "@aws-sdk/credential-provider-ini": "3.749.0",
+                "@aws-sdk/credential-provider-node": "3.749.0",
+                "@aws-sdk/credential-provider-process": "3.749.0",
+                "@aws-sdk/credential-provider-sso": "3.749.0",
+                "@aws-sdk/credential-provider-web-identity": "3.749.0",
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.749.0.tgz",
+            "integrity": "sha512-ecmuDu8EPya1LDpGRtpgN7C9PHayDh8EaW37ZBKhuxA7cg099yvTFqsGngwRXbhNjKJ4oVa9OUe0EDnu60atYA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.749.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.3",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.4",
+                "@smithy/middleware-retry": "^4.0.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.5",
+                "@smithy/util-defaults-mode-node": "^4.0.5",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.749.0.tgz",
+            "integrity": "sha512-w5Jj573+XKwrDNZUjUJDXL5upx+RCw64TLq3Zk8FVg9MsgkzAPorQ9qmzffi6os+PWngd3pFmD8q5y+Y35LpFQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.749.0.tgz",
+            "integrity": "sha512-bhB1ds5QzcSfmCTbjVessXy8xHJROota6wOhFtBsL1aZRQyNN2a9h2QS6xkxjmqVE3yHBsPz+OiSOeLn0kxm7Q==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.749.0.tgz",
+            "integrity": "sha512-enFGT8uvETbE6+4bDA2aTOrA/83GrIVPpg2g2r7MwJb36jreXA3KDXaP/5jQsxyIZW70cnYNl/Cawdd4ZXs7CQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.749.0.tgz",
+            "integrity": "sha512-OB4AGK61lQdoW2mTmaMBw8L+eBo7wF3YJZXwqFI7M2cQe9WtfuKGIxbYWMBMzoLvEtmsbzeppoZZUezooaIclg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/credential-provider-env": "3.749.0",
+                "@aws-sdk/credential-provider-http": "3.749.0",
+                "@aws-sdk/credential-provider-process": "3.749.0",
+                "@aws-sdk/credential-provider-sso": "3.749.0",
+                "@aws-sdk/credential-provider-web-identity": "3.749.0",
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.749.0.tgz",
+            "integrity": "sha512-1QGstZmGmgmY0rLSTAURlBJdR4s2PRYiZh6dS4HkzzQu7xVDWoCMD+2F7dolsNA8ChTNx2OvBW80n3O9QPICCg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.749.0",
+                "@aws-sdk/credential-provider-http": "3.749.0",
+                "@aws-sdk/credential-provider-ini": "3.749.0",
+                "@aws-sdk/credential-provider-process": "3.749.0",
+                "@aws-sdk/credential-provider-sso": "3.749.0",
+                "@aws-sdk/credential-provider-web-identity": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.749.0.tgz",
+            "integrity": "sha512-C/cgg/AhRabybZRY9mJ6KDz8uqfasWKuFIFGzTpeb/MIDIL53ZqP61CspiQJTRvC4zlFGqvm43XefphfrBGGlQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.749.0.tgz",
+            "integrity": "sha512-bQNgWcYk10fYOvFwcLskYYVNLO3KMgmV1ip9ieapJb9JDg6bSBaXNjIDhdpK4biTOfrV+adtDO5EU93ogpmAWA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.749.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/token-providers": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.749.0.tgz",
+            "integrity": "sha512-jzHk6i4G4dnXL+L+qeILguDCiIhA1rNvJzB5lTts4R8OdmNkG12bGbYL8bL4O1b5qCimlo7HS0IZIby0pS7rcg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.749.0.tgz",
+            "integrity": "sha512-dNRkZtiM8OoGb/h2Fgrgvty9ltYEubzsD5FH+VN14RrluertLQMmqHrgvq7JoAXFf7MJy+uwhRu4V6pf1sZR/w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.749.0.tgz",
+            "integrity": "sha512-s3ExVWoNZan6U7ljMqjiHq3bOe4EqL+U+cVPwqNxAsMaJpGyCiA8VQFlXNGg0EPAFbz/0DVBcozYht6/vyH3sg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.749.0.tgz",
+            "integrity": "sha512-uBzolGGrwvZKhpYlGIy9tw6gRdqVs2zyjjXUiifdgbr3WiQXJe8sE1KhLjzyN/VOPcZB0rY34ybqiKEDOymOeQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.4.tgz",
+            "integrity": "sha512-wFExFGK+7r2wYriOqe7RRIBNpvxwiS95ih09+GSLRBdoyK/O1uZA7K7pKesj5CBvwJuSBeXwLyR88WwIAY+DGA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.5.tgz",
+            "integrity": "sha512-cPzGZV7qStHwboFrm6GfrzQE+YDiCzWcTh4+7wKrP/ZQ4gkw+r7qDjV8GjM4N0UYsuUyLfpzLGg5hxsYTU11WA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.4",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.6.tgz",
+            "integrity": "sha512-s8QzuOQnbdvRymD9Gt9c9zMq10wUQAHQ3z72uirrBHCwZcLTrL5iCOuVTMdka2IXOYhQE890WD5t6G24+F+Qcg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
+            "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.5.tgz",
+            "integrity": "sha512-DMXYoYeL4QkElr216n1yodTFeATbfb4jwYM9gKn71Rw/FNA1/Sm36tkTSCsZEs7mgpG3OINmkxL9vgVFzyGPaw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.4",
+                "@smithy/middleware-endpoint": "^4.0.5",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.6.tgz",
+            "integrity": "sha512-N8+VCt+piupH1A7DgSVDNrVHqRLz8r6DvBkpS7EWHiIxsUk4jqGuQLjqC/gnCzmwGkVBdNruHoYAzzaSQ8e80w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.6.tgz",
+            "integrity": "sha512-9zhx1shd1VwSSVvLZB8CM3qQ3RPD3le7A3h/UPuyh/PC7g4OaWDi2xUNzamsVoSmCGtmUBONl56lM2EU6LcH7A==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.1.tgz",
+            "integrity": "sha512-+Xvh8nhy0Wjv1y71rBVyV3eJU3356XsFQNI8dEZVNrQju7Eib8G31GWtO+zMa9kTCGd41Mflu+ZKfmQL/o2XzQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                }
+            ],
+            "optional": true,
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
@@ -1284,6 +3452,858 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.749.0.tgz",
+            "integrity": "sha512-5L8OuVojcVQAZw+iVXTaw88AZTlMw8fD51lB6spzbZdNLl6dd5Iz1JVJAOUl2mTAZXRiN5Q9VECwY1yMgWweAw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/middleware-host-header": "3.734.0",
+                "@aws-sdk/middleware-logger": "3.734.0",
+                "@aws-sdk/middleware-recursion-detection": "3.734.0",
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/region-config-resolver": "3.734.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@aws-sdk/util-user-agent-browser": "3.734.0",
+                "@aws-sdk/util-user-agent-node": "3.749.0",
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/core": "^3.1.3",
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/hash-node": "^4.0.1",
+                "@smithy/invalid-dependency": "^4.0.1",
+                "@smithy/middleware-content-length": "^4.0.1",
+                "@smithy/middleware-endpoint": "^4.0.4",
+                "@smithy/middleware-retry": "^4.0.5",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.5",
+                "@smithy/util-defaults-mode-node": "^4.0.5",
+                "@smithy/util-endpoints": "^3.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.749.0.tgz",
+            "integrity": "sha512-w5Jj573+XKwrDNZUjUJDXL5upx+RCw64TLq3Zk8FVg9MsgkzAPorQ9qmzffi6os+PWngd3pFmD8q5y+Y35LpFQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/signature-v4": "^5.0.1",
+                "@smithy/smithy-client": "^4.1.4",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
+            "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
+            "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
+            "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.749.0.tgz",
+            "integrity": "sha512-dNRkZtiM8OoGb/h2Fgrgvty9ltYEubzsD5FH+VN14RrluertLQMmqHrgvq7JoAXFf7MJy+uwhRu4V6pf1sZR/w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/core": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@aws-sdk/util-endpoints": "3.743.0",
+                "@smithy/core": "^3.1.3",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
+            "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.743.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
+            "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-endpoints": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.734.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
+            "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.749.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.749.0.tgz",
+            "integrity": "sha512-uBzolGGrwvZKhpYlGIy9tw6gRdqVs2zyjjXUiifdgbr3WiQXJe8sE1KhLjzyN/VOPcZB0rY34ybqiKEDOymOeQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.749.0",
+                "@aws-sdk/types": "3.734.0",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
+            "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.4.tgz",
+            "integrity": "sha512-wFExFGK+7r2wYriOqe7RRIBNpvxwiS95ih09+GSLRBdoyK/O1uZA7K7pKesj5CBvwJuSBeXwLyR88WwIAY+DGA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-stream": "^4.1.1",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
+            "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
+            "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
+            "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
+            "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
+            "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.5.tgz",
+            "integrity": "sha512-cPzGZV7qStHwboFrm6GfrzQE+YDiCzWcTh4+7wKrP/ZQ4gkw+r7qDjV8GjM4N0UYsuUyLfpzLGg5hxsYTU11WA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.4",
+                "@smithy/middleware-serde": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/url-parser": "^4.0.1",
+                "@smithy/util-middleware": "^4.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.6.tgz",
+            "integrity": "sha512-s8QzuOQnbdvRymD9Gt9c9zMq10wUQAHQ3z72uirrBHCwZcLTrL5iCOuVTMdka2IXOYhQE890WD5t6G24+F+Qcg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-retry": "^4.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
+            "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
+            "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
+            "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/shared-ini-file-loader": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
+            "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
+            "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
+            "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
+            "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
+            "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
+            "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.5.tgz",
+            "integrity": "sha512-DMXYoYeL4QkElr216n1yodTFeATbfb4jwYM9gKn71Rw/FNA1/Sm36tkTSCsZEs7mgpG3OINmkxL9vgVFzyGPaw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^3.1.4",
+                "@smithy/middleware-endpoint": "^4.0.5",
+                "@smithy/middleware-stack": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-stream": "^4.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
+            "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.6.tgz",
+            "integrity": "sha512-N8+VCt+piupH1A7DgSVDNrVHqRLz8r6DvBkpS7EWHiIxsUk4jqGuQLjqC/gnCzmwGkVBdNruHoYAzzaSQ8e80w==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.6.tgz",
+            "integrity": "sha512-9zhx1shd1VwSSVvLZB8CM3qQ3RPD3le7A3h/UPuyh/PC7g4OaWDi2xUNzamsVoSmCGtmUBONl56lM2EU6LcH7A==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.0.1",
+                "@smithy/credential-provider-imds": "^4.0.1",
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/property-provider": "^4.0.1",
+                "@smithy/smithy-client": "^4.1.5",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
+            "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
+            "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
+            "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.1.tgz",
+            "integrity": "sha512-+Xvh8nhy0Wjv1y71rBVyV3eJU3356XsFQNI8dEZVNrQju7Eib8G31GWtO+zMa9kTCGd41Mflu+ZKfmQL/o2XzQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/fast-xml-parser": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                }
+            ],
+            "optional": true,
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
@@ -2945,6 +5965,16 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
             "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
+        },
+        "node_modules/@mongodb-js/saslprep": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
+            "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
+            }
         },
         "node_modules/@mux/mux-player": {
             "version": "3.1.0",
@@ -6816,6 +9846,12 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
         },
+        "node_modules/@types/bluebird": {
+            "version": "3.5.42",
+            "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
+            "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
+            "dev": true
+        },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -6857,6 +9893,15 @@
             "version": "0.5.8",
             "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
             "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
+        },
+        "node_modules/@types/continuation-local-storage": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.7.tgz",
+            "integrity": "sha512-Q7dPOymVpRG5Zpz90/o26+OAqOG2Sw+FED7uQmTrJNCF/JAPTylclZofMxZKd6W7g1BDPmT9/C/jX0ZcSNTQwQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/cookies": {
             "version": "0.9.0",
@@ -7053,6 +10098,19 @@
                 "@types/koa": "*"
             }
         },
+        "node_modules/@types/koa2-ratelimit": {
+            "version": "0.9.6",
+            "resolved": "https://registry.npmjs.org/@types/koa2-ratelimit/-/koa2-ratelimit-0.9.6.tgz",
+            "integrity": "sha512-ID+KPUlenR9RaJEazUMphzicrwZnG+cJ+9W+O+kQijJcKh5nTAo523YrRjLP0lMfAW7ouXjkvcL4M+z/Ihoydw==",
+            "dev": true,
+            "dependencies": {
+                "@types/koa": "*",
+                "@types/node": "*",
+                "@types/redis": "^2.8.0",
+                "@types/sequelize": "*",
+                "mongoose": "^6.3.0"
+            }
+        },
         "node_modules/@types/liftoff": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/@types/liftoff/-/liftoff-4.0.3.tgz",
@@ -7167,6 +10225,15 @@
                 "@types/react": "*"
             }
         },
+        "node_modules/@types/redis": {
+            "version": "2.8.32",
+            "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
+            "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/responselike": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -7182,6 +10249,18 @@
             "dependencies": {
                 "@types/mime": "^1",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/sequelize": {
+            "version": "4.28.20",
+            "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.28.20.tgz",
+            "integrity": "sha512-XaGOKRhdizC87hDgQ0u3btxzbejlF+t6Hhvkek1HyphqCI4y7zVBIVAGmuc4cWJqGpxusZ1RiBToHHnNK/Edlw==",
+            "dev": true,
+            "dependencies": {
+                "@types/bluebird": "*",
+                "@types/continuation-local-storage": "*",
+                "@types/lodash": "*",
+                "@types/validator": "*"
             }
         },
         "node_modules/@types/serve-static": {
@@ -7216,6 +10295,28 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
             "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+        },
+        "node_modules/@types/validator": {
+            "version": "13.12.2",
+            "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
+            "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==",
+            "dev": true
+        },
+        "node_modules/@types/webidl-conversions": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+            "devOptional": true
+        },
+        "node_modules/@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "devOptional": true,
+            "dependencies": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
         },
         "node_modules/@ucast/core": {
             "version": "1.10.2",
@@ -8089,6 +11190,18 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/bson": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+            "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+            "devOptional": true,
+            "dependencies": {
+                "buffer": "^5.6.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/buffer": {
@@ -12051,6 +15164,19 @@
                 "loose-envify": "^1.0.0"
             }
         },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "devOptional": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -12481,6 +15607,12 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "devOptional": true
+        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -12618,6 +15750,15 @@
             "dependencies": {
                 "jwa": "^2.0.0",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/kareem": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+            "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/keygrip": {
@@ -13504,6 +16645,13 @@
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
             "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
         },
+        "node_modules/memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "dev": true,
+            "optional": true
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -13695,6 +16843,83 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
+        "node_modules/mongodb": {
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+            "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+            "devOptional": true,
+            "dependencies": {
+                "bson": "^4.7.2",
+                "mongodb-connection-string-url": "^2.6.0",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">=12.9.0"
+            },
+            "optionalDependencies": {
+                "@aws-sdk/credential-providers": "^3.186.0",
+                "@mongodb-js/saslprep": "^1.1.0"
+            }
+        },
+        "node_modules/mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "devOptional": true,
+            "dependencies": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
+            }
+        },
+        "node_modules/mongoose": {
+            "version": "6.13.8",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.8.tgz",
+            "integrity": "sha512-JHKco/533CyVrqCbyQsnqMpLn8ZCiKrPDTd2mvo2W7ygIvhygWjX2wj+RPjn6upZZgw0jC6U51RD7kUsyK8NBg==",
+            "devOptional": true,
+            "dependencies": {
+                "bson": "^4.7.2",
+                "kareem": "2.5.1",
+                "mongodb": "4.17.2",
+                "mpath": "0.9.0",
+                "mquery": "4.0.3",
+                "ms": "2.1.3",
+                "sift": "16.0.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mongoose"
+            }
+        },
+        "node_modules/mongoose/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "devOptional": true
+        },
+        "node_modules/mpath": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+            "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/mquery": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+            "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+            "devOptional": true,
+            "dependencies": {
+                "debug": "4.x"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/mrmime": {
             "version": "2.0.0",
@@ -17664,12 +20889,36 @@
                 "slate": ">=0.65.3"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "devOptional": true,
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
         "node_modules/snake-case": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
             "integrity": "sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==",
             "dependencies": {
                 "no-case": "^2.2.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+            "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+            "devOptional": true,
+            "dependencies": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
             }
         },
         "node_modules/sorted-array-functions": {
@@ -17713,6 +20962,16 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "memory-pager": "^1.0.2"
             }
         },
         "node_modules/spawn-command": {
@@ -18485,6 +21744,18 @@
             "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
             "bin": {
                 "nodetouch": "bin/nodetouch.js"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "devOptional": true,
+            "dependencies": {
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/tree-kill": {
@@ -19364,6 +22635,15 @@
                 "defaults": "^1.0.3"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/webpack": {
             "version": "5.98.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
@@ -19522,6 +22802,19 @@
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "devOptional": true,
+            "dependencies": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "@strapi/plugin-users-permissions": "^5.10.2",
         "@strapi/provider-upload-aws-s3": "^5.10.2",
         "@strapi/strapi": "^5.10.2",
+        "koa2-ratelimit": "^1.1.3",
         "music-metadata": "^10.9.0",
         "pg": "~8.13.1",
         "prettify-xml": "^1.2.0",
@@ -24,6 +25,7 @@
         "styled-components": "~6.1.15"
     },
     "devDependencies": {
+        "@types/koa2-ratelimit": "^0.9.6",
         "@types/node": "^20.17.18",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",

--- a/src/middlewares/rate-limit.ts
+++ b/src/middlewares/rate-limit.ts
@@ -1,0 +1,17 @@
+import {RateLimit} from "koa2-ratelimit";
+import type {Core} from "@strapi/strapi";
+import {Context, Next} from "koa";
+
+// https://strapi.io/blog/how-to-set-up-rate-limiting-in-strapi-best-practices-and-examples
+export default (_config: any, {}: { strapi: Core.Strapi }) => {
+    return async (ctx: Context, next: Next) => {
+        return RateLimit.middleware({
+            interval: {
+                min: 3
+            },
+            max: 100, // limit each IP to 100 requests per minute
+            message: "Too many requests, please try again later.",
+            headers: true,
+        })(ctx, next);
+    };
+};


### PR DESCRIPTION
Introduce a custom rate-limiting middleware to restrict each IP to 100 requests per minute using `koa2-ratelimit`. This helps to prevent abuse and improve application stability. Updated dependencies and middleware configuration accordingly.